### PR TITLE
Make vox miners and engineers spawn with a n2 tank in their survival box

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -234,11 +234,11 @@
 		H.equip_or_collect(new /obj/item/clothing/shoes/black(H), slot_shoes)
 //		H.equip_or_collect(new /obj/item/clothing/gloves/black(H), slot_gloves)
 		if(H.backbag == 1)
-			H.put_in_hand(GRASP_RIGHT_HAND, new /obj/item/weapon/storage/box/survival/engineer(H))
+			H.put_in_hand(GRASP_RIGHT_HAND, new H.species.extended_survival_gear(H))
 			H.put_in_hands(new /obj/item/weapon/crowbar(H))
 			H.equip_or_collect(new /obj/item/weapon/storage/bag/ore(H), slot_l_store)
 		else
-			H.equip_or_collect(new /obj/item/weapon/storage/box/survival/engineer(H.back), slot_in_backpack)
+			H.equip_or_collect(new H.species.extended_survival_gear(H.back), slot_in_backpack)
 			H.equip_or_collect(new /obj/item/weapon/crowbar(H), slot_in_backpack)
 			H.equip_or_collect(new /obj/item/weapon/storage/bag/ore(H), slot_in_backpack)
 		return 1

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -41,9 +41,9 @@
 		H.equip_or_collect(new /obj/item/weapon/storage/belt/utility/full(H), slot_belt)
 		H.equip_or_collect(new /obj/item/clothing/gloves/black(H), slot_gloves)
 		if(H.backbag == 1)
-			H.put_in_hand(GRASP_RIGHT_HAND, new /obj/item/weapon/storage/box/survival/engineer(H))
+			H.put_in_hand(GRASP_RIGHT_HAND, new H.species.extended_survival_gear(H))
 		else
-			H.equip_or_collect(new /obj/item/weapon/storage/box/survival/engineer(H.back), slot_in_backpack)
+			H.equip_or_collect(new H.species.extended_survival_gear(H.back), slot_in_backpack)
 		return 1
 
 
@@ -92,9 +92,9 @@
 		H.equip_or_collect(new /obj/item/device/t_scanner(H), slot_r_store)
 		//H.equip_or_collect(new /obj/item/device/pda/engineering(H), slot_l_store)
 		if(H.backbag == 1)
-			H.put_in_hand(GRASP_RIGHT_HAND, new /obj/item/weapon/storage/box/survival/engineer(H))
+			H.put_in_hand(GRASP_RIGHT_HAND, new H.species.extended_survival_gear(H))
 		else
-			H.equip_or_collect(new /obj/item/weapon/storage/box/survival/engineer(H.back), slot_in_backpack)
+			H.equip_or_collect(new H.species.extended_survival_gear(H.back), slot_in_backpack)
 		return 1
 
 
@@ -132,9 +132,9 @@
 		//H.equip_or_collect(new /obj/item/device/pda/atmos(H), slot_l_store)
 		H.equip_or_collect(new /obj/item/weapon/storage/belt/utility/atmostech(H), slot_belt)
 		if(H.backbag == 1)
-			H.put_in_hand(GRASP_RIGHT_HAND, new /obj/item/weapon/storage/box/survival/engineer(H))
+			H.put_in_hand(GRASP_RIGHT_HAND, new H.species.extended_survival_gear(H))
 		else
-			H.equip_or_collect(new /obj/item/weapon/storage/box/survival/engineer(H.back), slot_in_backpack)
+			H.equip_or_collect(new H.species.extended_survival_gear(H.back), slot_in_backpack)
 		return 1
 
 /datum/job/mechanic
@@ -179,7 +179,7 @@
 			H.equip_or_collect(W, slot_head)
 			W.toggle()
 		if(H.backbag == 1)
-			H.put_in_hand(GRASP_RIGHT_HAND, new /obj/item/weapon/storage/box/survival/engineer(H))
+			H.put_in_hand(GRASP_RIGHT_HAND, new H.species.extended_survival_gear(H))
 		else
-			H.equip_or_collect(new /obj/item/weapon/storage/box/survival/engineer(H.back), slot_in_backpack)
+			H.equip_or_collect(new H.species.extended_survival_gear(H.back), slot_in_backpack)
 		return 1

--- a/code/game/jobs/job/paramedic.dm
+++ b/code/game/jobs/job/paramedic.dm
@@ -30,9 +30,9 @@
 		H.equip_or_collect(new /obj/item/device/flashlight/pen(H), slot_s_store)
 		H.equip_or_collect(new /obj/item/weapon/reagent_containers/hypospray/autoinjector/biofoam_injector(H), slot_l_store)
 		if(H.backbag == 1)
-			H.put_in_hand(GRASP_RIGHT_HAND, new /obj/item/weapon/storage/box/survival/engineer(H))
+			H.put_in_hand(GRASP_RIGHT_HAND, new H.species.extended_survival_gear(H))
 			H.put_in_hand(GRASP_LEFT_HAND, new /obj/item/device/healthanalyzer(H))
 		else
-			H.equip_or_collect(new /obj/item/weapon/storage/box/survival/engineer(H.back), slot_in_backpack)
+			H.equip_or_collect(new H.species.extended_survival_gear(H.back), slot_in_backpack)
 			H.equip_or_collect(new /obj/item/device/healthanalyzer(H.back), slot_in_backpack)
 		return 1

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -51,6 +51,7 @@ var/global/list/whitelisted_species = list("Human")
 
 	var/breath_type = "oxygen"   // Non-oxygen gas breathed, if any.
 	var/survival_gear = /obj/item/weapon/storage/box/survival // For spawnin'.
+	var/extended_survival_gear = /obj/item/weapon/storage/box/survival/engineer //For spawning with better internals
 
 	var/cold_level_1 = 260  // Cold damage level 1 below this point.
 	var/cold_level_2 = 200  // Cold damage level 2 below this point.
@@ -353,8 +354,8 @@ var/global/list/whitelisted_species = list("Human")
 	deform = 'icons/mob/human_races/vox/r_voxboney.dmi' //Do bones deform noticeably?
 	known_languages = list(LANGUAGE_VOX, LANGUAGE_CLATTER)
 
-	survival_gear = /obj/item/weapon/storage/box/survival/vox
-
+	survival_gear = /obj/item/weapon/storage/box/survival/vox //These are a subtype of skeletons and don't breathe, why do they get survival gear anyways?
+	extended_survival_gear = /obj/item/weapon/storage/box/survival/vox //They don't actually get a bigger N2 tank because they already get one by default
 	primitive = /mob/living/carbon/monkey/vox //for now
 
 	warning_low_pressure = 50
@@ -579,6 +580,7 @@ var/global/list/whitelisted_species = list("Human")
 	anatomy_flags = HAS_SWEAT_GLANDS
 
 	survival_gear = /obj/item/weapon/storage/box/survival/vox
+	extended_survival_gear = /obj/item/weapon/storage/box/survival/vox //Same as skelevox
 
 	primitive = /mob/living/carbon/monkey/vox
 


### PR DESCRIPTION
This doesn't spawn them with an extended N2 tank because they already spawn with a big N2 tank by default in the first place