### PR TITLE
Fix raising job preference in the job selection under wine/obsolete versions of IE

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -409,7 +409,7 @@ var/const/MAX_SAVE_SLOTS = 8
 				}
 
 			function mouseUp(event,levelup,leveldown,rank){
-				if(event.button == 0)
+				if(event.button == 0 || event.button == 1)
 					{
 					//alert("left click " + levelup + " " + rank);
 					setJobPrefRedirect(1, rank);
@@ -424,7 +424,7 @@ var/const/MAX_SAVE_SLOTS = 8
 
 				return true;
 				}
-			</script>"}
+			</script>"} //the event.button == 1 check is brought to you by legacy IE running in wine
 
 
 	HTML += {"<center>


### PR DESCRIPTION
See http://www.quirksmode.org/js/events_properties.html#button for an explanation of the values and why this happens
This also makes it so the middle mouse buttons raises the preferences when clicked over the buttons on modern versions of IE, but I don't think that really matters