### PR TITLE
Fix bluespace tomato having incorrect tech level definition

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -608,11 +608,11 @@
 	plantname = "tomato"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/bluespacetomato
-	name = "tomato" //"blue-space" is applied on new(), provided it's teleporting trait hasn't been removed
+	name = "tomato" //"blue-space" is applied on new(), provided its teleporting trait hasn't been removed
 	desc = "Its juices lubricate so well, you might slip through space-time."
 	icon_state = "bluespacetomato"
 	potency = 20
-	origin_tech = "bluespace = 3"
+	origin_tech = Tc_BLUESPACE + "=3"
 	filling_color = "#91F8FF"
 	plantname = "bluespacetomato"
 


### PR DESCRIPTION
There are defines to set the tech levels and it's a good practice to use them (this was causing the bluespace tomatoes to have a tech level of "bluespace " = 3, and that's just not correct) 