### PR TITLE
Make catwalks mouse opaque

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -7,6 +7,7 @@
 	anchored = 1.0
 	plane = ABOVE_PLATING_PLANE
 	layer = CATWALK_LAYER
+	mouse_opacity = 2
 
 	canSmoothWith = "/obj/structure/catwalk=0"
 


### PR DESCRIPTION
This ought to make doing stuff like wiring on catwalks a bit less painful now that they don't have holes to space when you're trying to click on them
