### PR TITLE
Make some types of vault mobs silent so they no longer spam their lines

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/monster.dm
+++ b/code/modules/mob/living/simple_animal/hostile/monster.dm
@@ -123,6 +123,11 @@
 	qdel(src)
 	return
 
+
+/mob/living/simple_animal/hostile/monster/cyber_horror/quiet
+	speak = list()
+
+
 /mob/living/simple_animal/hostile/monster/cyber_horror/Vox
 	name = "vox cyber horror"
 	desc = "What was once a vox, twisted and warped by machine."

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -295,3 +295,6 @@
 
 /obj/item/projectile/beam/pulse/drone
 	damage = 7
+
+/mob/living/simple_animal/hostile/retaliate/malf_drone/vault
+	speak = list() //Cuts down on spam


### PR DESCRIPTION
Note that there were already separate subtypes for the vault mobs, this just makes it so their lines don't spam deadchat