### PR TITLE
AAC sanity

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -366,29 +366,33 @@ Class Procs:
 		return 1
 	if(href_list["close"])
 		return
-	var/ghost_flags=0
-	if(ghost_write)
-		ghost_flags |= PERMIT_ALL
-	if(!canGhostWrite(usr,src,"",ghost_flags))
-		if(usr.restrained() || usr.lying || usr.stat)
-			return 1
-		if (!usr.dexterity_check())
-			to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
-			return 1
-		var/turf/T = get_turf(usr)
-		if(!isAI(usr) && T.z != z)
-			if(usr.z != map.zCentcomm)
-				to_chat(usr, "<span class='warning'>WARNING: Unable to interface with \the [src.name].</span>")
-				return 1
-		if ((!in_range(src, usr) || !istype(src.loc, /turf)) && !istype(usr, /mob/living/silicon))
-			return 1
-	else if(!custom_aghost_alerts)
-		log_adminghost("[key_name(usr)] screwed with [src] ([href])!")
-
+	if(!can_use_topic(usr, href))
+		return 1
 	src.add_fingerprint(usr)
 	src.add_hiddenprint(usr)
 
 	return handle_multitool_topic(href,href_list,usr)
+
+/obj/machinery/proc/can_use_topic(var/mob/user, var/href)
+	var/ghost_flags=0
+	if(ghost_write)
+		ghost_flags |= PERMIT_ALL
+	if(!canGhostWrite(user,src,"",ghost_flags))
+		if(user.restrained() || user.lying || user.stat)
+			return 0
+		if (!user.dexterity_check())
+			to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
+			return 0
+		var/turf/T = get_turf(user)
+		if(!isAI(user) && T.z != z)
+			if(user.z != map.zCentcomm)
+				to_chat(user, "<span class='warning'>WARNING: Unable to interface with \the [src.name].</span>")
+				return 0
+		if ((!in_range(src, user) || !istype(src.loc, /turf)) && !istype(user, /mob/living/silicon))
+			return 0
+	else if(!custom_aghost_alerts)
+		log_adminghost("[key_name(usr)] screwed with [src] ([href])!")
+	return 1
 
 /obj/machinery/attack_ai(mob/user as mob)
 	src.add_hiddenprint(user)

--- a/code/modules/atmos_automation/statements.dm
+++ b/code/modules/atmos_automation/statements.dm
@@ -107,7 +107,7 @@ var/global/automation_types=typesof(/datum/automation) - /datum/automation
 
 /datum/automation/Topic(var/href, var/list/href_list)
 	var/ghost_flags = 0
-	if(parent.ghost_write)
+	if(parent.ghost_write)  //this is just some (poor) copypasta of the original machinery Topic()'s checks
 		ghost_flags |= PERMIT_ALL
 
 	if(!canGhostWrite(usr, parent, "", ghost_flags))
@@ -313,7 +313,7 @@ var/global/automation_types=typesof(/datum/automation) - /datum/automation
 
 	. += "<b>ELSE:</b> (<a href=\"?src=\ref[src];add=else\">Add</a>)"
 
-	if(children_then.len)
+	if(children_else.len)
 		. += "<ul>"
 		for(var/datum/automation/stmt in children_else)
 			. += {"<li>
@@ -327,6 +327,8 @@ var/global/automation_types=typesof(/datum/automation) - /datum/automation
 
 /datum/automation/if_statement/Topic(var/href, var/list/href_list)
 	. = ..(href, href_list - list("add", "remove", "reset")) // So we can do sanity but not make it trigger on these specific hrefs overriden with shitcode here.
+	if(.)
+		return 1
 	if(href_list["add"])
 		var/new_child = selectValidChildFor(usr)
 		if(!new_child)

--- a/code/modules/atmos_automation/statements.dm
+++ b/code/modules/atmos_automation/statements.dm
@@ -106,29 +106,8 @@ var/global/automation_types=typesof(/datum/automation) - /datum/automation
 	return str || "-----"
 
 /datum/automation/Topic(var/href, var/list/href_list)
-	var/ghost_flags = 0
-	if(parent.ghost_write)  //this is just some (poor) copypasta of the original machinery Topic()'s checks
-		ghost_flags |= PERMIT_ALL
-
-	if(!canGhostWrite(usr, parent, "", ghost_flags))
-		if(usr.restrained() || usr.lying || usr.stat)
-			return 1
-
-		if (!usr.dexterity_check())
-			to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
-			return 1
-
-		var/norange = 0
-		if(usr.mutations && usr.mutations.len)
-			if(M_TK in usr.mutations)
-				norange = 1
-
-		if(!norange)
-			if ((!in_range(parent, usr) || !istype(parent.loc, /turf)) && !istype(usr, /mob/living/silicon))
-				return 1
-
-	else if(!parent.custom_aghost_alerts)
-		log_adminghost("[key_name(usr)] screwed with [parent] ([href])!")
+	if(!parent.can_use_topic(usr, href))
+		return 1
 
 	if(href_list["add"])
 		var/new_child = selectValidChildFor(usr)


### PR DESCRIPTION
Stops ghosts from changing things in IF statements in the AACs and splits off checking whether users of a machine can actually use the topic into its own function to reduce copypasted code