### PR TITLE
Plant analyzer now lists the names of the reagents instead of the ids

### DIFF
--- a/code/modules/hydroponics/hydro_tools.dm
+++ b/code/modules/hydroponics/hydro_tools.dm
@@ -83,7 +83,7 @@
 
 		dat += "<br>This sample contains: "
 		for(var/datum/reagent/R in grown_reagents.reagent_list)
-			dat += "<br>- [R.id], [grown_reagents.get_reagent_amount(R.id)] unit(s)"
+			dat += "<br>- [R.name], [grown_reagents.get_reagent_amount(R.id)] unit(s)"
 
 	dat += "<h2>Other Data</h2>"
 


### PR DESCRIPTION
Listing the actual ids looked ugly, the names are better for displaying