### PR TITLE
Make SMES units always go last in processing

### DIFF
--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -3,7 +3,7 @@
 	suspend_alert = 1
 	if(announce)
 		command_alert(/datum/command_alert/power_outage)
-	for(var/obj/machinery/power/battery/smes/S in power_machines)
+	for(var/obj/machinery/power/battery/smes/S in batteries)
 		if(istype(get_area(S), /area/turret_protected) || S.z != map.zMainStation)
 			continue
 		S.stat |= FORCEDISABLE
@@ -57,7 +57,7 @@
 		if(C.cell && C.z == map.zMainStation)
 			C.cell.charge = Clamp(C.cell.charge, C.old_charge, C.cell.maxcharge)
 			C.chargemode = 1
-	for(var/obj/machinery/power/battery/smes/S in power_machines)
+	for(var/obj/machinery/power/battery/smes/S in batteries)
 		if(S.z != map.zMainStation)
 			continue
 		S.stat &= ~FORCEDISABLE

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1161,7 +1161,7 @@ Pressure: [env.return_pressure()]"}
 
 	sleep(50) //Extra five seconds for the radiation collectors to get their shit together
 
-	for(var/obj/machinery/power/battery/smes/SMES in power_machines)
+	for(var/obj/machinery/power/battery/smes/SMES in batteries)
 		if(SMES.anchored)
 			SMES.connect_to_network() //Just in case.
 			SMES.chargemode = 1
@@ -1178,7 +1178,7 @@ Pressure: [env.return_pressure()]"}
 	log_admin("[key_name(usr)] haxed the powergrid with magic SMES.")
 	message_admins("<span class='notice'>[key_name_admin(usr)] haxed the powergrid with magic SMES.</span>", 1)
 
-	for(var/obj/machinery/power/battery/smes/SMES in power_machines)
+	for(var/obj/machinery/power/battery/smes/SMES in batteries)
 		var/turf/T=SMES.loc
 		del(SMES)
 		var/obj/machinery/power/battery/smes/infinite/magic = new(T)

--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -73,6 +73,15 @@ var/global/list/battery_online =	list(
 
 	machine_flags = SCREWTOGGLE | CROWDESTROY
 
+/obj/machinery/power/battery/New()
+	. = ..()
+	power_machines -= src
+	batteries |= src
+
+/obj/machinery/power/battery/Destroy()
+	batteries -= src
+	. = ..()
+
 /obj/machinery/power/battery/RefreshParts()
 	var/capcount = 0
 	var/lasercount = 0


### PR DESCRIPTION
<!--
Pull requests must be atomic.  Change one set of related things at a time.  Bundling sucks for everyone.
This means, primarily, that you shouldn't fix bugs and add content in the same PR. When we mean 'bundling', we mean making one PR for multiple, unrelated changes.

Test your changes.  PRs that do not compile will not be accepted.
Testing your changes locally is incredibly important. If you break the serb we will be very upset with you.

Large changes require discussion.  If you're doing a large, game-changing modification, or a new layout for something, discussion with the community is required as of 26/6/2014.  Map and sprite changes require pictures of before and after.  MAINTAINERS ARE NOT IMMUNE TO THIS.  GET YOUR ASS IN IRC.

Merging your own PRs is considered bad practice, as it generally means you bypass peer review, which is a core part of how we develop.

It is also suggested that you hop into irc.rizon.net #vgstation to discuss your changes, or if you need help.

When working with in body changelogs, the syntax is as follows:
:cl: (as the emoji)
 * rscadd: Did stuff!
 * rscdel: did other stuff!

for the keys you can use in a changelog, they are the same as described in html/changelogs/example.yml
NOTE that anything *after* the :cl: will be parsed as a changelog, if it somehow manages to be parseable as such, so always put the changelog at the VERY end!
-->
